### PR TITLE
Add Google Analytics tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,6 +42,23 @@ export default function RootLayout({
             `,
           }}
         />
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-099FT30VFS"
+          strategy="afterInteractive"
+        />
+        <Script
+          id="google-analytics"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', 'G-099FT30VFS');
+            `,
+          }}
+        />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased font-[family-name:var(--font-geist-sans)] bg-white dark:bg-gray-900 transition-colors`}


### PR DESCRIPTION
## Summary
- load Google Analytics tag script in the root layout
- initialize gtag configuration for property G-099FT30VFS after the app becomes interactive

## Testing
- `npm run lint` *(fails: npm command not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331c766c08832a8cefab92b0f1d0ca)